### PR TITLE
Implementation of the script Raytracing

### DIFF
--- a/Assets/Scriptes/raytracing.cs
+++ b/Assets/Scriptes/raytracing.cs
@@ -8,6 +8,8 @@ public class raytracing : MonoBehaviour
     public float viewAngle  = 5;
     Collider2D[] playerInRadius;
     [SerializeField] LayerMask obstacleMask, playerMask;
+    private LayerMask target;
+    GameObject objTarget;
     public float speed = 10;
     public List<Transform> visiblePlayer = new List<Transform>();
 
@@ -46,10 +48,15 @@ public class raytracing : MonoBehaviour
                 float distancePlayer = Vector2.Distance(transform.position, player.position);
                 if (!Physics2D.Raycast(transform.position, dirPlayer, distancePlayer, obstacleMask) && player != transform)
                 {
+                    objTarget = player.gameObject;
+                    // take the LayerMask and convert it, in int for compare with layer
+                    int layer = (int) Mathf.Log(playerMask.value, 2);
+                    if (objTarget.layer == layer) {
                     /*draw the line when contact with other player*/
-                    Debug.DrawLine(transform.position, player.position, Color.white, 0);
-                    if (!visiblePlayer.Contains(player))
-                        visiblePlayer.Add(player);
+                        Debug.DrawLine(transform.position, player.position, Color.white, 0);
+                        if (!visiblePlayer.Contains(player))
+                            visiblePlayer.Add(player);
+                    }
                 }
             }
         }

--- a/Assets/Scriptes/raytracing.cs
+++ b/Assets/Scriptes/raytracing.cs
@@ -37,18 +37,19 @@ public class raytracing : MonoBehaviour
     {
         playerInRadius = Physics2D.OverlapCircleAll(transform.position, viewRadius);
 
-        for (int i = 1; i < playerInRadius.Length; i++)
+        for (int i = 0; i < playerInRadius.Length; i++)
         {
             Transform player = playerInRadius[i].transform;
             Vector2 dirPlayer = new Vector2(player.position.x - transform.position.x, player.position.y - transform.position.y);
             if (Vector2.Angle(dirPlayer, transform.right) < viewAngle / 2)
             {
                 float distancePlayer = Vector2.Distance(transform.position, player.position);
-                if (!Physics2D.Raycast(transform.position, dirPlayer, distancePlayer, obstacleMask))
+                if (!Physics2D.Raycast(transform.position, dirPlayer, distancePlayer, obstacleMask) && player != transform)
                 {
                     /*draw the line when contact with other player*/
                     Debug.DrawLine(transform.position, player.position, Color.white, 0);
-                    visiblePlayer.Add(player);
+                    if (!visiblePlayer.Contains(player))
+                        visiblePlayer.Add(player);
                 }
             }
         }

--- a/Assets/Scriptes/raytracing.cs
+++ b/Assets/Scriptes/raytracing.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class raytracing : MonoBehaviour
+{
+    public bool Rotation = false;
+    public float viewRadius  = 5;
+    public float viewAngle  = 5;
+    Collider2D[] playerInRadius;
+    [SerializeField] LayerMask obstacleMask, playerMask;
+    public float speed = 10;
+    public List<Transform> visiblePlayer = new List<Transform>();
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Rotation == true) {
+            if (Input.GetKey(KeyCode.RightArrow))
+                transform.Rotate(-Vector3.forward * speed * Time.deltaTime);
+
+            if (Input.GetKey(KeyCode.LeftArrow))
+                transform.Rotate(Vector3.forward * speed * Time.deltaTime);
+        }
+    }
+
+    void FixedUpdate() 
+    {
+       FindVisiblePlayer();
+    }
+    void FindVisiblePlayer()
+    {
+        playerInRadius = Physics2D.OverlapCircleAll(transform.position, viewRadius);
+
+        for (int i = 1; i < playerInRadius.Length; i++)
+        {
+            Transform player = playerInRadius[i].transform;
+            Vector2 dirPlayer = new Vector2(player.position.x - transform.position.x, player.position.y - transform.position.y);
+            if (Vector2.Angle(dirPlayer, transform.right) < viewAngle / 2)
+            {
+                float distancePlayer = Vector2.Distance(transform.position, player.position);
+                if (!Physics2D.Raycast(transform.position, dirPlayer, distancePlayer, obstacleMask))
+                {
+                    /*draw the line when contact with other player*/
+                    Debug.DrawLine(transform.position, player.position, Color.white, 0);
+                    visiblePlayer.Add(player);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scriptes/raytracing.cs.meta
+++ b/Assets/Scriptes/raytracing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e565ad22ae3ccab3a8d5e26965abdf70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,8 +12,8 @@ TagManager:
   - Water
   - UI
   - Post Processing
-  - 
-  - 
+  - Obstacle
+  - Player
   - 
   - 
   - 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,8 +12,13 @@ TagManager:
   - Water
   - UI
   - Post Processing
+<<<<<<< HEAD
   - obstacle
   - 
+=======
+  - Obstacle
+  - Player
+>>>>>>> 042a079... [ADD] Change Layer
   - 
   - 
   - 


### PR DESCRIPTION
Add of the script Raytracing that you can use on any GameObject. You need to chose the ViewRadius and ViewAngle of the GameObject to determine a perimeter to detect the targets. You can define the target with the PlayerMask and the obstacle with  ObstacleMask.